### PR TITLE
Bugfix: fixed 'ComponentLookupError' error when adding a local user

### DIFF
--- a/collective/xmpp/core/protocols.py
+++ b/collective/xmpp/core/protocols.py
@@ -155,12 +155,12 @@ class AdminHandler(XMPPHandler):
         http://xmpp.org/extensions/xep-0133.html
     """
 
-    def getRegisteredUsers(self):
+    def getRegisteredUsers(self, portal=None):
         """ XXX: This is ejabberd specific. ejabberd does not implement
         the #get-registered-users-list command, instead does it with an iq/get.
         """
         iq = IQ(self.xmlstream, 'get')
-        iq['to'] = users.getXMPPDomain() 
+        iq['to'] = users.getXMPPDomain(portal)
         query = iq.addElement((NS_DISCO_ITEMS, 'query'))
         query['node'] = 'all users'
         d = iq.send()

--- a/collective/xmpp/core/storage.py
+++ b/collective/xmpp/core/storage.py
@@ -1,10 +1,12 @@
 import string
 import random
+import logging
 from BTrees.OOBTree import OOBTree
 from persistent import Persistent
 from zope.interface import implements
 from collective.xmpp.core.interfaces import IXMPPPasswordStorage
 
+logger = logging.getLogger(__name__)
 chars = string.letters + string.digits
 
 class XMPPPasswordStorage(Persistent):
@@ -29,5 +31,6 @@ class XMPPPasswordStorage(Persistent):
 
     def clear(self):
         self._passwords.clear()
+        logger.warning("The password storage has been wiped.")
 
 

--- a/collective/xmpp/core/utils/users.py
+++ b/collective/xmpp/core/utils/users.py
@@ -4,13 +4,17 @@ from twisted.words.protocols.jabber.xmlstream import IQ
 
 from zope.component.hooks import getSite
 from zope.component import getUtility
+from zope.component.interfaces import ComponentLookupError
 from Products.CMFCore.utils import getToolByName
 from plone.registry.interfaces import IRegistry
 
 from collective.xmpp.core.interfaces import IXMPPSettings
 
-def getXMPPDomain():
-    registry = getUtility(IRegistry)
+def getXMPPDomain(portal=None):
+    try:
+        registry = getUtility(IRegistry)
+    except ComponentLookupError:
+        registry = getUtility(IRegistry, context=portal)
     settings = registry.forInterface(IXMPPSettings, check=False)
     return settings.xmpp_domain
 
@@ -92,7 +96,7 @@ def setupPrincipal(client, principal_jid, principal_password):
 
             return result
 
-        d = client.admin.getRegisteredUsers()
+        d = client.admin.getRegisteredUsers(site)
         d.addCallbacks(resultReceived)
         return True
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,8 @@ Changelog
 
 - Feature: "Completely wipe password storage" action is now traced under zope log.
   [alecghica]
+- Bugfix: fixed 'ComponentLookupError' error when adding a local user.
+  [alecghica]
 
 
 0.1b4 (2013-02-02)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,8 @@ Changelog
 0.1b5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Feature: "Completely wipe password storage" action is now traced under zope log.
+  [alecghica]
 
 
 0.1b4 (2013-02-02)
@@ -120,7 +121,7 @@ Changelog
   [alecghica]
 - Fixed version used for Products.UserAndGroupSelectionWidget to >2.04
   as earlier version will crash due to API changes
-  [ghicaale]
+  [alecghica]
 - Bugfix. Password utility forgets user passwords when a user is registered.
   [jcbrand]
 


### PR DESCRIPTION
Bugfix: fixed 'ComponentLookupError' error when adding a local user.
[alecghica]

Feature: "Completely wipe password storage" action is now traced under zope log.
[alecghica]

See more under #15
